### PR TITLE
Force port to be an integer

### DIFF
--- a/bin/ursus
+++ b/bin/ursus
@@ -35,7 +35,7 @@ if __name__ == '__main__':
         help="Log level for ursus lint (INFO, WARNING, ERROR). Errors below this level are ignored."
     )
     parser.add_argument(
-        '-s', '--serve', dest='port', nargs='?', const=80, default=None,
+        '-s', '--serve', dest='port', nargs='?', const=80, type=int, default=None,
         help="Start a static file server, and serve the generated website on the given port. The default port is 80."
     )
     parser.add_argument(


### PR DESCRIPTION
Currently ursus fails when running it with the port:

```
$ ursus --serve 80
2024-08-18 12:09:41 INFO [root:64] Loaded config from ./ursus_config.py
Traceback (most recent call last):
  File "/Users/izidor/Library/Caches/pypoetry/virtualenvs/env-py3.12/bin/ursus", line 72, in <module>
    serve(args.port)
  File "/Users/izidor/Library/Caches/pypoetry/virtualenvs/env-py3.12/lib/python3.12/site-packages/ursus/server.py", line 40, in serve
    with socketserver.ThreadingTCPServer(("", port), HttpRequestHandler) as server:
         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/homebrew/Cellar/python@3.12/3.12.4/Frameworks/Python.framework/Versions/3.12/lib/python3.12/socketserver.py", line 457, in __init__
    self.server_bind()
  File "/opt/homebrew/Cellar/python@3.12/3.12.4/Frameworks/Python.framework/Versions/3.12/lib/python3.12/socketserver.py", line 473, in server_bind
    self.socket.bind(self.server_address)
TypeError: 'str' object cannot be interpreted as an integer
```