### PR TITLE
Add flair to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,8 @@
 # Ursus
 
+[![PyPI version](https://badge.fury.io/py/ursus-ssg.svg)](https://badge.fury.io/py/ursus-ssg)
+[![License](https://img.shields.io/github/license/All-About-Berlin/ursus.svg)](LICENSE)
+
 Ursus is the static site generator used by [All About Berlin](https://allaboutberlin.com) and my [personal website](https://nicolasbouliane.com). It turns Markdown files and [Jinja](https://jinja.palletsprojects.com/) templates into a static website.
 
 It also renders images in different sizes, renders SCSS, minifies JS and generates Lunr.js search indexes.


### PR DESCRIPTION
This adds some flair with badges for

- Pypi version
- Licence used - should work after https://github.com/All-About-Berlin/ursus/pull/6 is merged