### PR TITLE
Add pipx installation notes

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,13 @@ This project is in active use and development.
 
 ### Installation
 
-Install Ursus with pip:
+Install Ursus with [pipx](https://pipx.pypa.io/):
+
+```bash
+pipx install ursus-ssg
+```
+
+Alternatively install with pip:
 
 ```bash
 pip install ursus-ssg


### PR DESCRIPTION
What about recommending pipx to install this to provide isolation for the dependencies?

Was unable to verify on Python 3.13 as it looks like one of the dependencies fails.

```
Collecting Pillow==10.3.0 (from ursus-ssg)
  Using cached pillow-10.3.0.tar.gz (46.6 MB)
  Installing build dependencies ... done
  Getting requirements to build wheel ... error
  error: subprocess-exited-with-error
  
  × Getting requirements to build wheel did not run successfully.
  │ exit code: 1
  ╰─> [21 lines of output]
      Traceback (most recent call last):
        File "/tmp/ursus-ssg/.venv/lib/python3.13/site-packages/pip/_vendor/pyproject_hooks/_in_process/_in_process.py", line 389, in <module>
          main()
          ~~~~^^
        File "/tmp/ursus-ssg/.venv/lib/python3.13/site-packages/pip/_vendor/pyproject_hooks/_in_process/_in_process.py", line 373, in main
          json_out["return_val"] = hook(**hook_input["kwargs"])
                                   ~~~~^^^^^^^^^^^^^^^^^^^^^^^^
        File "/tmp/ursus-ssg/.venv/lib/python3.13/site-packages/pip/_vendor/pyproject_hooks/_in_process/_in_process.py", line 143, in get_requires_for_build_wheel
          return hook(config_settings)
        File "/tmp/pip-build-env-p1eatksy/overlay/lib/python3.13/site-packages/setuptools/build_meta.py", line 331, in get_requires_for_build_wheel
          return self._get_build_requires(config_settings, requirements=[])
                 ~~~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
        File "/tmp/pip-build-env-p1eatksy/overlay/lib/python3.13/site-packages/setuptools/build_meta.py", line 301, in _get_build_requires
          self.run_setup()
          ~~~~~~~~~~~~~~^^
        File "/tmp/pip-build-env-p1eatksy/overlay/lib/python3.13/site-packages/setuptools/build_meta.py", line 317, in run_setup
          exec(code, locals())
          ~~~~^^^^^^^^^^^^^^^^
        File "<string>", line 33, in <module>
        File "<string>", line 27, in get_version
      KeyError: '__version__'
      [end of output]
  
  note: This error originates from a subprocess, and is likely not a problem with pip.

```

Although looks like it should be supported https://github.com/python-pillow/Pillow/issues/9060